### PR TITLE
Pythonize PSD estimators and simplify trace PSD dispatcher

### DIFF
--- a/functions/TurbPy.py
+++ b/functions/TurbPy.py
@@ -67,6 +67,13 @@ import astropy.units as u
 from scipy.stats import binned_statistic
 from scipy.interpolate import interp1d
 
+from psd_estimators import (
+    FFTTracePSD,
+    HaarWaveletPSD,
+    MODWTTracePSD,
+    PyCWTWaveletPSD,
+    SSqueezepyWaveletPSD,
+)
 
 
 
@@ -547,47 +554,13 @@ def Trace_PSD_MODWT(R, T, N, dt, wname ='sym8'):
 #         print(f'Cadence is high.Switch  wname ={wname} to capture steep scalings!')
         
     
-    # Estimate MODWT coefficients and weights
-    Wr, Vj   = modwt.modwt(R, wtf=wname, nlevels='conservative', boundary='reflection', RetainVJ=True)
-    Wt, Vj   = modwt.modwt(T, wtf=wname, nlevels='conservative', boundary='reflection', RetainVJ=True)
-    Wn, Vj   = modwt.modwt(N, wtf=wname, nlevels='conservative', boundary='reflection', RetainVJ=True)
-    
-    # Return freqs and scales too
-    scale = 2**np.arange(1,np.shape(Wr)[0]+1);
-    freqs = pywt.scale2frequency('coif6', scale)/dt
-   
-    # Estimate Fsc_{ii} and PSD = Σ Fsc_{ii}
-    PSD_R = modwt.wspec(Wr, dt)
-    PSD_T = modwt.wspec(Wt, dt)
-    PSD_N = modwt.wspec(Wn, dt)
-    
-    return freqs, 2*(PSD_R[0] + PSD_T[0] + PSD_N[0]), scale
+    estimator = MODWTTracePSD(wname=wname)
+    return estimator.estimate(R, T, N, dt)
 
 
 def Trace_haar_wavelet_psd(x, y, z, dt, wavelet='haar'):
-
-    # Perform the wavelet decomposition on the padded data
-    x = pywt.wavedec(x, wavelet)
-    y = pywt.wavedec(y, wavelet)
-    z = pywt.wavedec(z, wavelet)
-    
-    px = []
-    py = []
-    pz = []
-    for i in range(1, len(x)):
-
-        px.append(np.nanmean(x[i]**2))
-        py.append(np.nanmean(y[i]**2))
-        pz.append(np.nanmean(z[i]**2))
-        
-    px       = dt*(np.array(px[::-1]))/np.log2(2)
-    py       = dt*(np.array(py[::-1]))/np.log2(2)
-    pz       = dt*(np.array(pz[::-1]))/np.log2(2)
-    p_trace  = px + py + pz
-    
-    freqs = 2.0**(-np.arange(1, len(px)+1))/dt
-
-    return x, y, z, freqs, p_trace, px, py, pz
+    estimator = HaarWaveletPSD(wavelet=wavelet)
+    return estimator.estimate(x, y, z, dt)
 
 
 def trace_PSD_wavelet(x,
@@ -625,32 +598,8 @@ def trace_PSD_wavelet(x,
         The scales at which wavelet was estimated
     """
     
-    mother_wave_dict = {
-    'gaussian': pycwt.DOG(),
-    'paul': pycwt.Paul(),
-    'mexican_hat': pycwt.MexicanHat()}
-    
-
-    if mother_wave in mother_wave_dict.keys():
-        mother_morlet = mother_wave_dict[mother_wave]
-    else:
-        mother_morlet = pycwt.Morlet()
-        
-    N                                       = len(x)
-
-
-    db_x, sj, freqs, coi, signal_ft, ftfreqs = pycwt.cwt(x, dt, dj, wavelet=mother_morlet)
-    db_y, _, freqs, _, _, _                  = pycwt.cwt(y, dt, dj, wavelet=mother_morlet)
-    db_z, _, freqs, _, _, _                  = pycwt.cwt(z, dt, dj, wavelet=mother_morlet)
-     
-    # Estimate trace powerspectral density
-    PSD = (np.nanmean(np.abs(db_x)**2, axis=1) + np.nanmean(np.abs(db_y)**2, axis=1) + np.nanmean(np.abs(db_z)**2, axis=1)   )*( 2*dt)
-    
-    # Remember!
-    scales = (1/(freqs))/dt
-    
-    
-    return db_x, db_y, db_z, freqs, PSD, scales
+    estimator = PyCWTWaveletPSD(dj=dj, mother_wave=mother_wave)
+    return estimator.estimate(x, y, z, dt)
 
 
 
@@ -694,49 +643,17 @@ def trace_PSD_cwt_ssqueezepy(x,
         The scales at which wavelet was estimated
     """
     
-    if wavelet is None:
-        wavelet    = ssqueezepy.Wavelet(('morlet', {'mu': 13.4}))
-    else:
-        wavelet    = ssqueezepy.Wavelet((wname, {'mu': 13.4}))  
-        
-    if  scales_type  is  None:
-        scales_type  = 'log'
-
-    # Estimate sampling frequency
-    fs          = 1/dt
-    
-    # Estimate wavelet coefficients
-    Wx, scales  = ssqueezepy.cwt(x, wavelet,  scales_type , fs, l1_norm=l1_norm, nv=nv)
-    Wy, _       = ssqueezepy.cwt(y, wavelet,  scales_type , fs, l1_norm=l1_norm, nv=nv)
-    Wz, _       = ssqueezepy.cwt(z, wavelet,  scales_type , fs, l1_norm=l1_norm, nv=nv)
-    
-    
-     
-    if est_mod:
-        Wmod , _  = ssqueezepy.cwt(np.sqrt(x**2 + y**2 + z**2), wavelet,  scales_type , fs, l1_norm=l1_norm, nv=nv)
-    else:
-        Wmod      = None
-    
-    # Estimate corresponding frequencies
-    freqs       = ssqueezepy.experimental.scale_to_freq(scales, wavelet, len(x), fs)
-    
-    # This is the correct one!
-    scales     = (omega0)/(2*np.pi*freqs)*(1  + 1/(2*omega0**2))*fs
-    
-    if est_PSD:
-        # Estimate trace powers pectral density
-        PSD        = (np.nanmean(np.abs(Wx)**2, axis=1) + np.nanmean(np.abs(Wy)**2, axis=1) + np.nanmean(np.abs(Wz)**2, axis=1)   )*( 2*dt)
-        
-        if est_mod:
-            PSD_mod = (np.nanmean(np.abs(Wmod)**2, axis=1)  )*( 2*dt)
-        else:
-            PSD_mod     = None
-    else:
-        PSD        = None
-        PSD_mod     = None
-    
-
-    return Wx, Wy, Wz, Wmod,  freqs, PSD, PSD_mod, scales 
+    estimator = SSqueezepyWaveletPSD(
+        nv=nv,
+        scales_type=scales_type,
+        wavelet=wavelet,
+        wname=wname,
+        l1_norm=l1_norm,
+        est_psd=est_PSD,
+        est_mod=est_mod,
+        omega0=omega0,
+    )
+    return estimator.estimate(x, y, z, dt)
 
 
 
@@ -1135,38 +1052,55 @@ def TracePSD(x, y, z, dt,
                - freqs (np.ndarray): Array of frequencies.
                - B_pow (np.ndarray): Power spectral density estimates of the trace or individual components and/or modulus.
     """
-    if not isinstance(x, np.ndarray):
-        x = x.values
-        y = y.values
-        z = z.values
+    estimator = FFTTracePSD(
+        remove_mean=remove_mean,
+        return_components=return_components,
+        return_mod=return_mod,
+    )
+    return estimator.estimate(x, y, z, dt)
 
-    if remove_mean:
-        x -= np.nanmean(x)
-        y -= np.nanmean(y)
-        z -= np.nanmean(z)
 
-    N = len(x)
+def estimate_trace_psd(
+    x,
+    y,
+    z,
+    dt,
+    method="traceFFT",
+    **kwargs,
+):
+    """
+    Dispatch trace PSD estimation across supported methods.
 
-    xf = np.fft.rfft(x)
-    yf = np.fft.rfft(y)
-    zf = np.fft.rfft(z)
+    Parameters
+    ----------
+    x, y, z : array-like
+        Components of the field.
+    dt : float
+        Sampling time step.
+    method : str, optional
+        PSD estimation method. Default is "traceFFT".
+        Supported: "traceFFT", "modwt", "haar", "pycwt", "ssqueezepy".
+    **kwargs
+        Method-specific keyword arguments forwarded to the underlying estimator.
 
-    p_X     = 2 * (np.abs(xf) ** 2) / N * dt
-    p_Y     = 2 * (np.abs(yf) ** 2) / N * dt
-    p_Z     = 2 * (np.abs(zf) ** 2) / N * dt
-    p_Trace = p_X + p_Y + p_Z
+    Returns
+    -------
+    tuple
+        Method-specific outputs from the selected PSD estimator.
+    """
 
-    freqs = np.fft.rfftfreq(N, dt)
-
-    if return_mod:
-        mod = np.sqrt(x**2 + y**2 + z**2)
-        p_Mod = 2 * (np.abs(np.fft.rfft(mod)) ** 2) / N * dt
-        return freqs, p_Trace, p_X, p_Y, p_Z, p_Mod
-
-    if return_components:
-        return freqs, p_Trace, p_X, p_Y, p_Z
-
-    return freqs, p_Trace
+    method_key = method.lower()
+    dispatch = {
+        "tracefft": TracePSD,
+        "modwt": Trace_PSD_MODWT,
+        "haar": Trace_haar_wavelet_psd,
+        "pycwt": trace_PSD_wavelet,
+        "ssqueezepy": trace_PSD_cwt_ssqueezepy,
+    }
+    estimator = dispatch.get(method_key)
+    if estimator is None:
+        raise ValueError(f"Unknown PSD method: {method}")
+    return estimator(x, y, z, dt, **kwargs)
 
 def Trace_psd_Hann(B,  dt, nperseg=2**14, noverlap=2**13):
     from scipy.signal import welch

--- a/functions/psd_estimators.py
+++ b/functions/psd_estimators.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+import os
+import sys
+
+import numpy as np
+import pycwt
+import pywt
+import ssqueezepy
+
+sys.path.insert(1, os.path.join(os.getcwd(), "functions/modwt/wmtsa"))
+import modwt
+
+
+def _as_array(values: Any) -> np.ndarray:
+    if isinstance(values, np.ndarray):
+        return values
+    return np.asarray(values)
+
+
+@dataclass(frozen=True)
+class FFTTracePSD:
+    remove_mean: bool = False
+    return_components: bool = False
+    return_mod: bool = False
+
+    def estimate(
+        self, x: Any, y: Any, z: Any, dt: float
+    ) -> Tuple[np.ndarray, ...]:
+        x = _as_array(x)
+        y = _as_array(y)
+        z = _as_array(z)
+
+        if self.remove_mean:
+            x -= np.nanmean(x)
+            y -= np.nanmean(y)
+            z -= np.nanmean(z)
+
+        n = len(x)
+        xf = np.fft.rfft(x)
+        yf = np.fft.rfft(y)
+        zf = np.fft.rfft(z)
+
+        p_x = 2 * (np.abs(xf) ** 2) / n * dt
+        p_y = 2 * (np.abs(yf) ** 2) / n * dt
+        p_z = 2 * (np.abs(zf) ** 2) / n * dt
+        p_trace = p_x + p_y + p_z
+
+        freqs = np.fft.rfftfreq(n, dt)
+
+        if self.return_mod:
+            mod = np.sqrt(x**2 + y**2 + z**2)
+            p_mod = 2 * (np.abs(np.fft.rfft(mod)) ** 2) / n * dt
+            return freqs, p_trace, p_x, p_y, p_z, p_mod
+
+        if self.return_components:
+            return freqs, p_trace, p_x, p_y, p_z
+
+        return freqs, p_trace
+
+
+@dataclass(frozen=True)
+class MODWTTracePSD:
+    wname: str = "sym8"
+
+    def estimate(
+        self, r: Any, t: Any, n: Any, dt: float
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        wr, _ = modwt.modwt(r, wtf=self.wname, nlevels="conservative", boundary="reflection", RetainVJ=True)
+        wt, _ = modwt.modwt(t, wtf=self.wname, nlevels="conservative", boundary="reflection", RetainVJ=True)
+        wn, _ = modwt.modwt(n, wtf=self.wname, nlevels="conservative", boundary="reflection", RetainVJ=True)
+
+        scale = 2 ** np.arange(1, np.shape(wr)[0] + 1)
+        freqs = pywt.scale2frequency("coif6", scale) / dt
+
+        psd_r = modwt.wspec(wr, dt)
+        psd_t = modwt.wspec(wt, dt)
+        psd_n = modwt.wspec(wn, dt)
+
+        return freqs, 2 * (psd_r[0] + psd_t[0] + psd_n[0]), scale
+
+
+@dataclass(frozen=True)
+class HaarWaveletPSD:
+    wavelet: str = "haar"
+
+    def estimate(
+        self, x: Any, y: Any, z: Any, dt: float
+    ) -> Tuple[Any, Any, Any, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        x = pywt.wavedec(x, self.wavelet)
+        y = pywt.wavedec(y, self.wavelet)
+        z = pywt.wavedec(z, self.wavelet)
+
+        px = np.array([np.nanmean(coeff**2) for coeff in x[1:]])
+        py = np.array([np.nanmean(coeff**2) for coeff in y[1:]])
+        pz = np.array([np.nanmean(coeff**2) for coeff in z[1:]])
+
+        px = dt * (px[::-1]) / np.log2(2)
+        py = dt * (py[::-1]) / np.log2(2)
+        pz = dt * (pz[::-1]) / np.log2(2)
+        p_trace = px + py + pz
+
+        freqs = 2.0 ** (-np.arange(1, len(px) + 1)) / dt
+
+        return x, y, z, freqs, p_trace, px, py, pz
+
+
+@dataclass(frozen=True)
+class PyCWTWaveletPSD:
+    dj: float = 1 / 2
+    mother_wave: str = "morlet"
+
+    def estimate(
+        self, x: Any, y: Any, z: Any, dt: float
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        mother_wave_dict = {
+            "gaussian": pycwt.DOG(),
+            "paul": pycwt.Paul(),
+            "mexican_hat": pycwt.MexicanHat(),
+        }
+
+        mother_morlet = mother_wave_dict.get(self.mother_wave, pycwt.Morlet())
+
+        db_x, _, freqs, _, _, _ = pycwt.cwt(x, dt, self.dj, wavelet=mother_morlet)
+        db_y, _, freqs, _, _, _ = pycwt.cwt(y, dt, self.dj, wavelet=mother_morlet)
+        db_z, _, freqs, _, _, _ = pycwt.cwt(z, dt, self.dj, wavelet=mother_morlet)
+
+        psd = (
+            np.nanmean(np.abs(db_x) ** 2, axis=1)
+            + np.nanmean(np.abs(db_y) ** 2, axis=1)
+            + np.nanmean(np.abs(db_z) ** 2, axis=1)
+        ) * (2 * dt)
+
+        scales = (1 / (freqs)) / dt
+
+        return db_x, db_y, db_z, freqs, psd, scales
+
+
+@dataclass(frozen=True)
+class SSqueezepyWaveletPSD:
+    nv: int = 16
+    scales_type: Optional[str] = "log"
+    wavelet: Optional[Any] = None
+    wname: Optional[str] = None
+    l1_norm: bool = False
+    est_psd: bool = True
+    est_mod: bool = False
+    omega0: float = 6.0
+
+    def estimate(
+        self, x: Any, y: Any, z: Any, dt: float
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, Optional[np.ndarray], np.ndarray, Optional[np.ndarray], Optional[np.ndarray], np.ndarray]:
+        if self.wavelet is None:
+            wavelet = ssqueezepy.Wavelet(("morlet", {"mu": 13.4}))
+        else:
+            wavelet = ssqueezepy.Wavelet((self.wname, {"mu": 13.4}))
+
+        scales_type = self.scales_type or "log"
+        fs = 1 / dt
+
+        wx, scales = ssqueezepy.cwt(x, wavelet, scales_type, fs, l1_norm=self.l1_norm, nv=self.nv)
+        wy, _ = ssqueezepy.cwt(y, wavelet, scales_type, fs, l1_norm=self.l1_norm, nv=self.nv)
+        wz, _ = ssqueezepy.cwt(z, wavelet, scales_type, fs, l1_norm=self.l1_norm, nv=self.nv)
+
+        if self.est_mod:
+            wmod, _ = ssqueezepy.cwt(
+                np.sqrt(x**2 + y**2 + z**2),
+                wavelet,
+                scales_type,
+                fs,
+                l1_norm=self.l1_norm,
+                nv=self.nv,
+            )
+        else:
+            wmod = None
+
+        freqs = ssqueezepy.experimental.scale_to_freq(scales, wavelet, len(x), fs)
+
+        scales = (self.omega0) / (2 * np.pi * freqs) * (1 + 1 / (2 * self.omega0**2)) * fs
+
+        if self.est_psd:
+            psd = (
+                np.nanmean(np.abs(wx) ** 2, axis=1)
+                + np.nanmean(np.abs(wy) ** 2, axis=1)
+                + np.nanmean(np.abs(wz) ** 2, axis=1)
+            ) * (2 * dt)
+
+            psd_mod = (np.nanmean(np.abs(wmod) ** 2, axis=1)) * (2 * dt) if self.est_mod else None
+        else:
+            psd = None
+            psd_mod = None
+
+        return wx, wy, wz, wmod, freqs, psd, psd_mod, scales
+
+
+PSD_ESTIMATORS: Dict[str, Any] = {
+    "fft": FFTTracePSD,
+    "modwt": MODWTTracePSD,
+    "haar": HaarWaveletPSD,
+    "pycwt": PyCWTWaveletPSD,
+    "ssqueezepy": SSqueezepyWaveletPSD,
+}
+
+
+def get_psd_estimator(method: str, **kwargs: Any) -> Any:
+    estimator = PSD_ESTIMATORS.get(method)
+    if estimator is None:
+        raise ValueError(f"Unknown PSD estimator method: {method}")
+    return estimator(**kwargs)


### PR DESCRIPTION
### Motivation
- Consolidate PSD logic into small, class-based estimators to make the code easier to extend and maintain while preserving existing numerical behavior. 
- Replace ad-hoc `if`/`elif` dispatcher logic with a more Pythonic mapping to make `estimate_trace_psd` and `TurbPy.py` easier to read and modify.

### Description
- Add `functions/psd_estimators.py` which implements dataclass-based estimators `FFTTracePSD`, `MODWTTracePSD`, `HaarWaveletPSD`, `PyCWTWaveletPSD`, and `SSqueezepyWaveletPSD`, plus the `PSD_ESTIMATORS` registry and `get_psd_estimator` helper. 
- Update `functions/TurbPy.py` to import the new estimator classes and delegate the former inline implementations by calling each estimator's `estimate` method for `Trace_PSD_MODWT`, `Trace_haar_wavelet_psd`, `trace_PSD_wavelet`, `trace_PSD_cwt_ssqueezepy`, and `TracePSD`. 
- Simplify `estimate_trace_psd` in `functions/TurbPy.py` by replacing the `if` chain with a dict-based `dispatch` mapping that preserves the same supported method keys (`traceFFT`, `modwt`, `haar`, `pycwt`, `ssqueezepy`) and raises on unknown methods. 
- Preserve compatibility with the local `modwt` package via the existing `sys.path` insertion so behavior remains unchanged.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989b798e3a48320a7d3b12e8da2fa1a)

## Summary by Sourcery

Introduce reusable PSD estimator classes and route existing trace PSD functions through them while simplifying method dispatch.

New Features:
- Add dataclass-based PSD estimator classes for FFT, MODWT, Haar wavelet, PyCWT, and SSqueezepy methods, plus a registry and factory helper for lookup by method name.

Enhancements:
- Refactor existing trace PSD functions in TurbPy to delegate to the new estimator classes, reducing inline implementation duplication.
- Replace the if/elif chain in estimate_trace_psd with a dictionary-based dispatcher over supported PSD methods.