### PR TITLE
Align PSD dispatch with registry, lazy-load modwt, and fix ssqueezepy wavelet handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ __pycache__/
 .ipynb_checkpoints/
 .DS_Store
 last_200_runs.txt
+*_runs.txt
+logs/
 psp_data/
 solar_orbiter_data/
 *.cdf

--- a/README.md
+++ b/README.md
@@ -1,61 +1,59 @@
-![MHDTurbpy](logo/final.png "turb")
-
+![MHDTurbPy](logo/final.png "turb")
 
 # MHDTurbPy
-A collection of functions for downloading, cleaning, and analyzing data from:
+MHDTurbPy is a Python toolkit for downloading, cleaning, and analyzing heliophysics spacecraft data from:
 
- - Parker Solar Probe
- - Solar Orbiter 
- - WIND
- - Helios A
- - Helios B
- - Ulysses
+- Parker Solar Probe
+- Solar Orbiter
+- WIND
+- Helios A
+- Helios B
+- Ulysses
 
-Additional functions and documentation will be added soon.
-
-
- I welcome contributions to this repository!
+Documentation and additional functionality are under active development, and contributions are welcome.
 
 
 
 # Installation
 
-
- Install virtualenv using pip:
+## 1) Download the package
 ```bash
- pip install virtualenv
- ```
-Create a new virtual environment: 
+git clone https://github.com/nsioulas/MHDTurbPy/
+cd MHDTurbPy
+```
+
+## 2) Create and activate a virtual environment
+Install virtualenv using pip:
+```bash
+pip install virtualenv
+```
+Create a new virtual environment:
 ```bash
 virtualenv MHDTurbPy
- ```
- Activate the virtual environment: 
- ```bash
- source MHDTurbPy/bin/activate
- ```
-
-Install the required packages from your environment file. Don't forget to change the path to your downloaded .txt file: 
+```
+Activate the virtual environment:
 ```bash
-pip install -r path/to/file/requirements.txt
- ```
- 
- To continue installing packages even if some fail, you can use a bash loop to try installing each package individually. This way, even if one package fails to install, the loop will proceed to the next package in the list. 
- 
-```bash
+source MHDTurbPy/bin/activate
+```
 
+## 3) Install dependencies
+Install the required packages from the repo requirements file:
+```bash
+pip install -r requirements/requirements.txt
+```
+
+If you need to continue installing packages even when some fail, you can try a bash loop that falls back to conda:
+
+```bash
 while read p; do
     pip install "$p" || (echo "Trying to install $p with conda" && conda install "$p" -y || echo "Failed to install $p with both pip and conda")
-done < /path/to/file/requirements.txt
- ```
-
- - Download the package
-``` bash
-git clone https://github.com/nsioulas/MHDTurbPy/
+done < requirements/requirements.txt
 ```
 
 # Usage
 
-Some examples of how to download, visualize data can be found in the folder ```Notebooks_Examples```
+Example notebooks that demonstrate how to download and visualize data are available in `Notebooks_Examples`.
+Start with the notebooks in `Notebooks_Examples/` if you want end-to-end data download and analysis examples.
 
 # Contact
 If you have any questions, please don't hesitate to reach out to nsioulas@g.ucla.edu.
@@ -76,6 +74,4 @@ If you use this work, please cite:
   url          = {https://doi.org/10.5281/zenodo.7572468}
 }
 ```
-
-
 

--- a/functions/TurbPy.py
+++ b/functions/TurbPy.py
@@ -73,6 +73,7 @@ from psd_estimators import (
     MODWTTracePSD,
     PyCWTWaveletPSD,
     SSqueezepyWaveletPSD,
+    get_psd_estimator,
 )
 
 
@@ -1079,7 +1080,7 @@ def estimate_trace_psd(
         Sampling time step.
     method : str, optional
         PSD estimation method. Default is "traceFFT".
-        Supported: "traceFFT", "modwt", "haar", "pycwt", "ssqueezepy".
+        Supported: "traceFFT" (alias for "fft"), "fft", "modwt", "haar", "pycwt", "ssqueezepy".
     **kwargs
         Method-specific keyword arguments forwarded to the underlying estimator.
 
@@ -1090,17 +1091,11 @@ def estimate_trace_psd(
     """
 
     method_key = method.lower()
-    dispatch = {
-        "tracefft": TracePSD,
-        "modwt": Trace_PSD_MODWT,
-        "haar": Trace_haar_wavelet_psd,
-        "pycwt": trace_PSD_wavelet,
-        "ssqueezepy": trace_PSD_cwt_ssqueezepy,
+    aliases = {
+        "tracefft": "fft",
     }
-    estimator = dispatch.get(method_key)
-    if estimator is None:
-        raise ValueError(f"Unknown PSD method: {method}")
-    return estimator(x, y, z, dt, **kwargs)
+    estimator = get_psd_estimator(aliases.get(method_key, method_key), **kwargs)
+    return estimator.estimate(x, y, z, dt)
 
 def Trace_psd_Hann(B,  dt, nperseg=2**14, noverlap=2**13):
     from scipy.signal import welch

--- a/functions/psd_estimators.py
+++ b/functions/psd_estimators.py
@@ -11,8 +11,20 @@ import pycwt
 import pywt
 import ssqueezepy
 
-sys.path.insert(1, os.path.join(os.getcwd(), "functions/modwt/wmtsa"))
-import modwt
+_MODWT_MODULE: Optional[Any] = None
+
+
+def _load_modwt() -> Any:
+    """Lazy-load modwt with an explicit path tweak to avoid import-time side effects."""
+    global _MODWT_MODULE
+    if _MODWT_MODULE is None:
+        modwt_path = os.path.join(os.getcwd(), "functions/modwt/wmtsa")
+        if modwt_path not in sys.path:
+            sys.path.insert(1, modwt_path)
+        import modwt  # noqa: WPS433 (import inside function for optional dependency)
+
+        _MODWT_MODULE = modwt
+    return _MODWT_MODULE
 
 
 def _as_array(values: Any) -> np.ndarray:
@@ -69,6 +81,7 @@ class MODWTTracePSD:
     def estimate(
         self, r: Any, t: Any, n: Any, dt: float
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        modwt = _load_modwt()
         wr, _ = modwt.modwt(r, wtf=self.wname, nlevels="conservative", boundary="reflection", RetainVJ=True)
         wt, _ = modwt.modwt(t, wtf=self.wname, nlevels="conservative", boundary="reflection", RetainVJ=True)
         wn, _ = modwt.modwt(n, wtf=self.wname, nlevels="conservative", boundary="reflection", RetainVJ=True)
@@ -153,10 +166,14 @@ class SSqueezepyWaveletPSD:
     def estimate(
         self, x: Any, y: Any, z: Any, dt: float
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, Optional[np.ndarray], np.ndarray, Optional[np.ndarray], Optional[np.ndarray], np.ndarray]:
-        if self.wavelet is None:
-            wavelet = ssqueezepy.Wavelet(("morlet", {"mu": 13.4}))
+        if self.wavelet is not None:
+            if isinstance(self.wavelet, ssqueezepy.Wavelet):
+                wavelet = self.wavelet
+            else:
+                wavelet = ssqueezepy.Wavelet(self.wavelet)
         else:
-            wavelet = ssqueezepy.Wavelet((self.wname, {"mu": 13.4}))
+            wname = self.wname or "morlet"
+            wavelet = ssqueezepy.Wavelet((wname, {"mu": 13.4}))
 
         scales_type = self.scales_type or "log"
         fs = 1 / dt
@@ -206,7 +223,7 @@ PSD_ESTIMATORS: Dict[str, Any] = {
 
 
 def get_psd_estimator(method: str, **kwargs: Any) -> Any:
-    estimator = PSD_ESTIMATORS.get(method)
+    estimator = PSD_ESTIMATORS.get(method.lower())
     if estimator is None:
         raise ValueError(f"Unknown PSD estimator method: {method}")
     return estimator(**kwargs)


### PR DESCRIPTION
### Motivation
- Centralize PSD estimator selection through the existing registry to avoid duplicate dispatch logic and reduce drift between dispatch maps.  
- Make the `SSqueezepyWaveletPSD` class accept and honor provided `Wavelet` instances or configuration instead of always building from `wname`.  
- Avoid surprising import-time side effects by removing the unconditional `sys.path` mutation for `modwt` and make the lookup for estimator names case-insensitive.

### Description
- Replaced the local dispatch in `estimate_trace_psd` with a call into the registry via `get_psd_estimator`, and added an alias map so `traceFFT` maps to the registry `fft` entry in `functions/TurbPy.py`.  
- Added `get_psd_estimator` import and updated the `estimate_trace_psd` docstring to list `traceFFT` as an alias for `fft`.  
- In `functions/psd_estimators.py` implemented a lazy loader `_load_modwt()` that inserts the `modwt` path only when needed and returns the module, removing the previous unconditional `sys.path` mutation at import time.  
- Made `SSqueezepyWaveletPSD.estimate` respect a provided `wavelet` value by using it directly if it is already an `ssqueezepy.Wavelet` or constructing one from the provided `wavelet` configuration; otherwise it falls back to `wname` or the default `"morlet"`.  
- Normalized the registry lookup by using `method.lower()` in `get_psd_estimator` to avoid case-sensitivity issues.

### Testing
- No automated tests were run for these logic-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989eb40ad3083209b93fbf6f9968afe)

## Summary by Sourcery

Align PSD estimation dispatch with the shared registry, improve wavelet configuration handling, and reduce import-time side effects for optional dependencies.

Enhancements:
- Route trace PSD estimation through the shared PSD estimator registry, treating traceFFT as an alias of fft and delegating to estimator instances instead of local dispatch classes.
- Make SSqueezepy-based PSD estimation respect provided Wavelet instances or configurations and fall back to a sensible default when none is given.
- Lazy-load the modwt dependency on first use rather than at import time, adding its path to sys.path only when needed, and make PSD estimator lookup case-insensitive.

Documentation:
- Clarify and expand the README with a clearer project description, step-by-step installation instructions using the repository requirements file, and improved usage guidance for example notebooks.