### PR TITLE
Codex-generated pull request

### DIFF
--- a/functions/TurbPy.py
+++ b/functions/TurbPy.py
@@ -1094,7 +1094,14 @@ def estimate_trace_psd(
     aliases = {
         "tracefft": "fft",
     }
-    estimator = get_psd_estimator(aliases.get(method_key, method_key), **kwargs)
+    estimator_key = aliases.get(method_key, method_key)
+    estimator_kwargs = dict(kwargs)
+    if estimator_key == "ssqueezepy":
+        if "est_PSD" in estimator_kwargs and "est_psd" not in estimator_kwargs:
+            estimator_kwargs["est_psd"] = estimator_kwargs.pop("est_PSD")
+        else:
+            estimator_kwargs.pop("est_PSD", None)
+    estimator = get_psd_estimator(estimator_key, **estimator_kwargs)
     return estimator.estimate(x, y, z, dt)
 
 def Trace_psd_Hann(B,  dt, nperseg=2**14, noverlap=2**13):


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989f3580f7083208f597239bfbdee56)

## Summary by Sourcery

Bug Fixes:
- Ensure ssqueezepy PSD estimator accepts the expected est_psd keyword by translating or dropping legacy est_PSD arguments to prevent errors.