### PR TITLE
Fix MODWT path resolution and clarify PSD estimator kwargs

### DIFF
--- a/functions/TurbPy.py
+++ b/functions/TurbPy.py
@@ -1082,7 +1082,8 @@ def estimate_trace_psd(
         PSD estimation method. Default is "traceFFT".
         Supported: "traceFFT" (alias for "fft"), "fft", "modwt", "haar", "pycwt", "ssqueezepy".
     **kwargs
-        Method-specific keyword arguments forwarded to the underlying estimator.
+        Method-specific keyword arguments forwarded to the underlying estimator
+        constructor.
 
     Returns
     -------

--- a/functions/psd_estimators.py
+++ b/functions/psd_estimators.py
@@ -18,7 +18,8 @@ def _load_modwt() -> Any:
     """Lazy-load modwt with an explicit path tweak to avoid import-time side effects."""
     global _MODWT_MODULE
     if _MODWT_MODULE is None:
-        modwt_path = os.path.join(os.getcwd(), "functions/modwt/wmtsa")
+        module_root = os.path.dirname(__file__)
+        modwt_path = os.path.join(module_root, "modwt", "wmtsa")
         if modwt_path not in sys.path:
             sys.path.insert(1, modwt_path)
         import modwt  # noqa: WPS433 (import inside function for optional dependency)


### PR DESCRIPTION
### Motivation
- Avoid brittle `os.getcwd()`-based resolution for the bundled `modwt` module so lazy imports work when the package is used from a different working directory, and make the `estimate_trace_psd` kwargs behavior explicit.

### Description
- Compute the `modwt` helper path relative to the `psd_estimators` module using `os.path.dirname(__file__)` and add it to `sys.path` in `_load_modwt` (file: `functions/psd_estimators.py`).
- Update the `estimate_trace_psd` docstring to clarify that `**kwargs` are forwarded to the estimator constructor rather than the `estimate` call (file: `functions/TurbPy.py`).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989f51c785083209a6f13fdb4436ea2)

## Summary by Sourcery

Clarify PSD estimator configuration and make MODWT helper loading more robust.

Bug Fixes:
- Resolve MODWT helper import by computing its path relative to the psd_estimators module instead of relying on the current working directory.

Documentation:
- Clarify in estimate_trace_psd documentation that additional keyword arguments are passed to the estimator constructor rather than its estimate method.