### PR TITLE
Make MODWT import path module-relative and clarify PSD kwargs

### DIFF
--- a/functions/TurbPy.py
+++ b/functions/TurbPy.py
@@ -1083,7 +1083,7 @@ def estimate_trace_psd(
         Supported: "traceFFT" (alias for "fft"), "fft", "modwt", "haar", "pycwt", "ssqueezepy".
     **kwargs
         Method-specific keyword arguments forwarded to the underlying estimator
-        constructor.
+        constructor (not its ``estimate`` method).
 
     Returns
     -------

--- a/functions/psd_estimators.py
+++ b/functions/psd_estimators.py
@@ -18,7 +18,7 @@ def _load_modwt() -> Any:
     """Lazy-load modwt with an explicit path tweak to avoid import-time side effects."""
     global _MODWT_MODULE
     if _MODWT_MODULE is None:
-        module_root = os.path.dirname(__file__)
+        module_root = os.path.dirname(os.path.abspath(__file__))
         modwt_path = os.path.join(module_root, "modwt", "wmtsa")
         if modwt_path not in sys.path:
             sys.path.insert(1, modwt_path)


### PR DESCRIPTION
### Motivation
- Make the MODWT helper import resilient to changes in the current working directory and clarify how kwargs are forwarded for PSD estimation.

### Description
- Resolve the psd_estimators module root with `os.path.dirname(os.path.abspath(__file__))` and construct the `modwt` helper path relative to it in `functions/psd_estimators.py` to avoid WD-dependent imports.
- Clarify `estimate_trace_psd` docstring in `functions/TurbPy.py` to note that `**kwargs` are forwarded to the estimator constructor (not its ``estimate`` method).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989fb1dbc3483208d8ad91992c500d9)

## Summary by Sourcery

Clarify PSD estimator configuration docs and make MODWT helper import path resolution robust to working directory changes.

Enhancements:
- Clarify that estimate_trace_psd forwards **kwargs to the PSD estimator constructor rather than its estimate method.
- Resolve the MODWT helper module path using an absolute path to avoid working-directory-dependent imports.