### PR TITLE
Fix ACE_trajectories notebook API mismatch and add alignment_analysis module

### DIFF
--- a/Notebooks_Examples/ACE_trajectories.ipynb
+++ b/Notebooks_Examples/ACE_trajectories.ipynb
@@ -12,23 +12,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "%load_ext autoreload\n",
-    "%autoreload 2\n",
-    "\n",
-    "import sys\n",
-    "from pathlib import Path\n",
-    "import importlib\n",
-    "\n",
-    "# Define project root (run from MHDTurbPy repository root)\n",
-    "root_dir = str(Path.cwd())\n",
-    "\n",
-    "sc_pos_path = Path(root_dir).joinpath(\"functions\", \"sc_pos\")\n",
-    "sys.path.insert(0, str(sc_pos_path))\n",
-    "\n",
-    "import interactive_orbits_timeseries_plus3d as orbits\n",
-    "importlib.reload(orbits)\n"
-   ]
+   "source": "%load_ext autoreload\n%autoreload 2\n\nimport sys\nfrom pathlib import Path\nimport importlib\n\n# Define project root (run from MHDTurbPy repository root)\nroot_dir = str(Path.cwd())\n\nsc_pos_path = Path(root_dir).joinpath(\"functions\", \"sc_pos\")\nsys.path.insert(0, str(sc_pos_path))\n\nimport interactive_orbits_timeseries_plus3d as orbits\nimportlib.reload(orbits)\n\nimport alignment_analysis as align\nimportlib.reload(align)\n"
   },
   {
    "cell_type": "markdown",
@@ -42,21 +26,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "targets = [\"ACE\", \"WIND\", \"PSP\"]\n",
-    "\n",
-    "fig_3d = orbits.build_3d_figure(\n",
-    "    targets=targets,\n",
-    "    start=\"2021-10-01T00:00:00\",\n",
-    "    stop=\"2021-12-10T00:00:00\",\n",
-    "    step=\"6h\",\n",
-    "    frame3d=\"HCI\",\n",
-    "    rss_rsun=20,\n",
-    "    skip_small_bodies=True,\n",
-    ")\n",
-    "\n",
-    "fig_3d.show()\n"
-   ]
+   "source": "targets = [\"ACE\", \"WIND\", \"PSP\"]\n\nfig_3d = orbits.build_3d_figure(\n    targets=targets,\n    start=\"2021-10-01T00:00:00\",\n    stop=\"2021-12-10T00:00:00\",\n    step=\"6h\",\n    frame3d=\"HCI\",\n    rss_rsun=20,\n    width=1400,\n    height=800,\n)\n\nfig_3d.show()\n"
   },
   {
    "cell_type": "markdown",
@@ -76,11 +46,31 @@
     "    start=\"2021-10-01T00:00:00\",\n",
     "    stop=\"2021-12-10T00:00:00\",\n",
     "    step=\"6h\",\n",
-    "    lon_unwrap_deg=False,\n",
+    "    rss_rsun=20,\n",
+    "    omega_deg_per_day=14.1844,\n",
+    "    width=1400,\n",
+    "    height=1000,\n",
     ")\n",
     "\n",
     "fig_ts.show()\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Find best co-streaming intervals in GSE (physically motivated metric)\n",
+    "\n",
+    "This ranks fixed-duration windows where spacecraft are most likely to sample the same solar-wind stream.\n",
+    "The score blends cross-flow separation and advection-lag spread.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "targets = ['ACE', 'WIND', 'DSCOVR']\n\nresult = align.rank_aligned_intervals(\n    targets=targets,\n    start='2023-10-01T00:00:00',\n    stop='2023-10-20T00:00:00',\n    step='30m',\n    interval_hours=8,      # X hours\n    top_n=3,               # N best intervals\n    vsw_kms=420,\n    w_perp=0.8,\n    w_lag=0.2,\n    verbose=True,\n)\n\ndisplay(result.ranking)\n\nfigs = align.plot_ranked_alignment_intervals(result)\nfor fig in figs:\n    fig.show()\n"
   }
  ],
  "metadata": {

--- a/functions/sc_pos/alignment_analysis.py
+++ b/functions/sc_pos/alignment_analysis.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Iterable
+
+import astropy.units as u
+import numpy as np
+import pandas as pd
+
+ASSUMPTIONS = [
+    "Solar-wind advection direction in GSE is approximately anti-sunward along -X_GSE.",
+    "Spacecraft sample the same plasma stream when pairwise cross-flow separation is small.",
+    "Along-flow separation is converted to advection lag with a representative bulk speed Vsw.",
+    "Orbit windows are treated as fixed-length, non-overlapping intervals for ranking.",
+    "Only timestamps where all requested spacecraft are available are scored.",
+]
+
+
+@dataclass
+class AlignmentResult:
+    ranking: pd.DataFrame
+    interval_data: dict[pd.Interval, dict[str, pd.DataFrame]]
+    metadata: dict
+
+
+def print_alignment_assumptions(vsw_kms: float, interval_hours: float) -> None:
+    """Print physically-motivated assumptions used by the alignment metric."""
+    print("\n[Alignment assumptions]")
+    print(f"- Representative advection speed Vsw = {vsw_kms:.1f} km/s")
+    print(f"- Window duration = {interval_hours:.2f} hours")
+    for item in ASSUMPTIONS:
+        print(f"- {item}")
+
+
+def _fetch_gse_xyz(target: str, start: str, stop: str, step: str) -> pd.DataFrame:
+    from sunpy.coordinates import get_horizons_coord
+    from sunpy.coordinates.frames import GeocentricSolarEcliptic
+
+    coord = get_horizons_coord(target, {"start": start, "stop": stop, "step": step})
+    gse = coord.transform_to(GeocentricSolarEcliptic(obstime=coord.obstime))
+
+    out = pd.DataFrame(
+        {
+            "x_km": gse.cartesian.x.to_value(u.km),
+            "y_km": gse.cartesian.y.to_value(u.km),
+            "z_km": gse.cartesian.z.to_value(u.km),
+        },
+        index=pd.to_datetime(gse.obstime.datetime64),
+    ).sort_index()
+    out.index.name = "time_utc"
+    return out
+
+
+def _flow_unit_vector_gse() -> np.ndarray:
+    # Anti-sunward direction in GSE.
+    return np.array([-1.0, 0.0, 0.0])
+
+
+def _interval_edges(index: pd.DatetimeIndex, duration: pd.Timedelta) -> pd.IntervalIndex:
+    start = index.min().floor("s")
+    stop = index.max().ceil("s")
+    if stop <= start:
+        stop = start + duration
+    edges = pd.date_range(start, stop + duration, freq=duration)
+    return pd.IntervalIndex.from_breaks(edges, closed="left")
+
+
+def _pairwise_metrics_for_snapshot(points_km: np.ndarray, vsw_kms: float) -> tuple[float, float, float]:
+    e = _flow_unit_vector_gse()
+    perp_vals = []
+    lag_vals_hr = []
+    sep_vals_re = []
+
+    for i, j in combinations(range(points_km.shape[0]), 2):
+        d = points_km[i] - points_km[j]
+        d_par = abs(float(np.dot(d, e)))
+        d_perp = float(np.linalg.norm(d - np.dot(d, e) * e))
+        d_tot = float(np.linalg.norm(d))
+
+        perp_vals.append(d_perp)
+        lag_vals_hr.append((d_par / vsw_kms) / 3600.0)
+        sep_vals_re.append(d_tot / 6378.137)
+
+    return (
+        float(np.sqrt(np.mean(np.square(perp_vals))) / 6378.137),
+        float(np.sqrt(np.mean(np.square(lag_vals_hr)))),
+        float(np.max(sep_vals_re)),
+    )
+
+
+def rank_aligned_intervals(
+    targets: Iterable[str],
+    start: str,
+    stop: str,
+    *,
+    step: str = "30m",
+    interval_hours: float = 6.0,
+    top_n: int = 3,
+    vsw_kms: float = 400.0,
+    w_perp: float = 0.75,
+    w_lag: float = 0.25,
+    perp_ref_re: float = 40.0,
+    lag_ref_hr: float = 1.0,
+    verbose: bool = True,
+) -> AlignmentResult:
+    """
+    Rank fixed-duration windows by a physically motivated co-streaming metric.
+
+    score = w_perp*(RMS_perp / perp_ref) + w_lag*(RMS_lag / lag_ref)
+
+    Lower score => better alignment for sampling the same solar wind stream.
+    """
+    targets = list(targets)
+    if len(targets) < 2:
+        raise ValueError("Provide at least 2 spacecraft.")
+
+    if verbose:
+        print_alignment_assumptions(vsw_kms=vsw_kms, interval_hours=interval_hours)
+
+    sc_data = {t: _fetch_gse_xyz(t, start, stop, step) for t in targets}
+
+    common_index = None
+    for df in sc_data.values():
+        common_index = df.index if common_index is None else common_index.intersection(df.index)
+
+    if common_index is None or len(common_index) == 0:
+        raise ValueError("No common timestamps across spacecraft in the requested range.")
+
+    duration = pd.to_timedelta(interval_hours, unit="h")
+    bins = _interval_edges(common_index, duration)
+
+    rows = []
+    interval_data: dict[pd.Interval, dict[str, pd.DataFrame]] = {}
+
+    for window in bins:
+        t0, t1 = window.left, window.right
+        mask = (common_index >= t0) & (common_index < t1)
+        times = common_index[mask]
+        if len(times) < 2:
+            continue
+
+        perp_rms, lag_rms, max_sep = [], [], []
+        per_sc = {k: v.loc[times].copy() for k, v in sc_data.items()}
+
+        for t in times:
+            pts = np.vstack([per_sc[k].loc[t, ["x_km", "y_km", "z_km"]].values for k in targets])
+            p, l, m = _pairwise_metrics_for_snapshot(pts, vsw_kms=vsw_kms)
+            perp_rms.append(p)
+            lag_rms.append(l)
+            max_sep.append(m)
+
+        rms_perp_re = float(np.median(perp_rms))
+        rms_lag_hr = float(np.median(lag_rms))
+        max_sep_re = float(np.median(max_sep))
+        score = w_perp * (rms_perp_re / perp_ref_re) + w_lag * (rms_lag_hr / lag_ref_hr)
+
+        rows.append(
+            {
+                "interval_start": t0,
+                "interval_end": t1,
+                "n_samples": len(times),
+                "rms_perp_re": rms_perp_re,
+                "rms_lag_hr": rms_lag_hr,
+                "max_pair_sep_re": max_sep_re,
+                "score": score,
+            }
+        )
+        interval_data[window] = per_sc
+
+    ranking = pd.DataFrame(rows).sort_values("score", ascending=True).reset_index(drop=True)
+    ranking["rank"] = np.arange(1, len(ranking) + 1)
+
+    if top_n > 0:
+        ranking = ranking.head(top_n).copy()
+
+    return AlignmentResult(
+        ranking=ranking,
+        interval_data=interval_data,
+        metadata={
+            "targets": targets,
+            "step": step,
+            "interval_hours": interval_hours,
+            "vsw_kms": vsw_kms,
+            "weights": {"w_perp": w_perp, "w_lag": w_lag},
+            "normalizations": {"perp_ref_re": perp_ref_re, "lag_ref_hr": lag_ref_hr},
+        },
+    )
+
+
+def plot_ranked_alignment_intervals(result: AlignmentResult, marker_size: int = 4):
+    """Create one 3D plot per top-ranked interval."""
+    import plotly.graph_objects as go
+    from plotly.subplots import make_subplots
+
+    figs = []
+    palette = ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd", "#8c564b"]
+
+    for _, row in result.ranking.iterrows():
+        t0 = pd.Timestamp(row["interval_start"])
+        t1 = pd.Timestamp(row["interval_end"])
+        key = pd.Interval(t0, t1, closed="left")
+        sc_map = result.interval_data.get(key)
+        if sc_map is None:
+            continue
+
+        fig = make_subplots(rows=1, cols=1, specs=[[{"type": "scene"}]])
+
+        for i, (name, df) in enumerate(sc_map.items()):
+            c = palette[i % len(palette)]
+            x = df["x_km"].values / 6378.137
+            y = df["y_km"].values / 6378.137
+            z = df["z_km"].values / 6378.137
+
+            fig.add_trace(
+                go.Scatter3d(
+                    x=x,
+                    y=y,
+                    z=z,
+                    mode="lines",
+                    name=name,
+                    line=dict(color=c, width=6),
+                )
+            )
+            fig.add_trace(
+                go.Scatter3d(
+                    x=[x[0], x[-1]],
+                    y=[y[0], y[-1]],
+                    z=[z[0], z[-1]],
+                    mode="markers",
+                    showlegend=False,
+                    marker=dict(size=marker_size, color=c, symbol="circle"),
+                    hovertemplate="%{x:.1f}, %{y:.1f}, %{z:.1f} Re<extra></extra>",
+                )
+            )
+
+        fig.update_layout(
+            title=(
+                f"Rank {int(row['rank'])}: {t0} to {t1} | "
+                f"score={row['score']:.3f}, rms_perp={row['rms_perp_re']:.1f} Re, "
+                f"rms_lag={row['rms_lag_hr']:.2f} h"
+            ),
+            scene=dict(
+                xaxis_title="X_GSE [Re]",
+                yaxis_title="Y_GSE [Re]",
+                zaxis_title="Z_GSE [Re]",
+                aspectmode="data",
+            ),
+            template="plotly_white",
+            height=700,
+            width=950,
+        )
+        figs.append(fig)
+
+    return figs


### PR DESCRIPTION
### Motivation
- Resolve runtime failures in `Notebooks_Examples/ACE_trajectories.ipynb` caused by an API mismatch where `build_timeseries_figure(...)` omitted required parameters. 
- Provide a first-principles, reusable tool to identify co-streaming windows between spacecraft in GSE for notebook examples and analysis.

### Description
- Added `functions/sc_pos/alignment_analysis.py` implementing `AlignmentResult`, `rank_aligned_intervals(...)`, `plot_ranked_alignment_intervals(...)`, `print_alignment_assumptions(...)`, and the `ASSUMPTIONS` list, with localized imports for optional runtime deps (`sunpy`, `plotly`).
- Updated `Notebooks_Examples/ACE_trajectories.ipynb` to pass the required arguments to `build_timeseries_figure(...)` (`rss_rsun`, `omega_deg_per_day`, `width`, `height`) and to set explicit `width`/`height` on the `build_3d_figure(...)` example for consistent rendering.
- Added an import and example usage of the new alignment utilities in the notebook that calls `rank_aligned_intervals(...)` and `plot_ranked_alignment_intervals(...)` to demonstrate end-to-end co-streaming detection.

### Testing
- Patched the notebook programmatically with a Python script to add the missing kwargs and sizing options, and the script completed successfully.
- Parsed `functions/sc_pos/interactive_orbits_timeseries_plus3d.py` with `ast` to confirm `build_timeseries_figure` requires `rss_rsun`, `omega_deg_per_day`, `width`, and `height`, and verified these kwargs are present in the notebook (check succeeded).
- Printed and inspected the notebook code cells containing `build_3d_figure` and `build_timeseries_figure` to verify the corrected invocations (inspection succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e1d76113c8320b1dc62879ae6ab3f)