### PR TITLE
Add SOLO daily merged-MAG availability notebook

### DIFF
--- a/Notebooks_Examples/SOLO_merged_MAG_daily_availability.ipynb
+++ b/Notebooks_Examples/SOLO_merged_MAG_daily_availability.ipynb
@@ -1,0 +1,62 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Solar Orbiter merged MAG availability (daily, non-overlapping)\n\nThis notebook is based on the `SOLO.ipynb` workflow, but forces:\n- `SOLO_use_merged_MAG = True`\n- 1-day non-overlapping intervals\n- 1-minute cadence diagnostics for `beta` and `sigma_c`\n\nIt also saves the **usual MHDTurbPy files** (`final.pkl`, `general.pkl`, `sig_c_sig_r.pkl`, and gap files) for each successful day.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from pathlib import Path\nimport importlib.util\nimport os\nimport json\n\nimport numpy as np\nimport pandas as pd\n\n\ndef _find_repo_root(start: Path) -> Path:\n    current = start.resolve()\n    for candidate in (current, *current.parents):\n        if (candidate / \"functions\").is_dir() and (candidate / \"pyspedas\").is_dir():\n            return candidate\n    raise RuntimeError(\"Could not locate MHDTurbPy root (missing functions/ and pyspedas/).\")\n\n\nroot_dir = _find_repo_root(Path.cwd())\npath_setup_file = root_dir / \"functions\" / \"path_setup.py\"\nspec = importlib.util.spec_from_file_location(\"mhdturbpy_path_setup\", path_setup_file)\nif spec is None or spec.loader is None:\n    raise RuntimeError(f\"Could not load path setup from {path_setup_file}\")\npath_setup = importlib.util.module_from_spec(spec)\nspec.loader.exec_module(path_setup)\n\nroot_dir = path_setup.ensure_project_paths(\n    start=Path.cwd(),\n    include_downloading_helpers=True,\n    include_anisotropy_toolbox=True,\n    include_sc_pos=True,\n)\n\nfrom functions import download_data as download\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# ---------- User configuration ----------\ncdf_lib_path = \"/Applications/cdf/cdf/lib\"   # Set to your local CDF lib path if needed\ncredentials = None\n\nstart_date = \"2022-10-01 00:00\"\nend_date   = \"2022-11-01 00:00\"  # end is exclusive for daily slicing\n\nsave_usual_files = True\nsave_base = Path(root_dir) / \"examples\" / \"downloaded_intervals\" / \"SOLO_merged_MAG_daily\"\n\nsettings = {\n    \"Data_path\": Path(root_dir) / \"data\",\n    \"save_destination\": Path(root_dir) / \"examples\" / \"downloaded_intervals\",\n    \"sc\": \"SOLO\",\n    \"in_rtn\": 0,\n    \"use_local_data\": False,\n\n    # interval controls\n    \"start_date\": start_date,\n    \"end_date\": end_date,\n    \"multiple_intervals\": False,\n    \"duration\": \"24H\",\n    \"Step\": \"24H\",\n    \"addit_time_around\": 1,\n\n    # force 1-minute cadence products\n    \"part_resol\": 60,\n    \"MAG_resol\": 60,\n    \"upsample_low_freq_ts\": False,\n\n    # quality + output\n    \"overwrite_files\": 1,\n    \"must_have_qtn\": False,\n    \"Max_par_missing\": 30,\n    \"gap_time_threshold\": 5,\n    \"save_all\": True,\n\n    # diagnostics needed for beta and sigma_c\n    \"estimate_derived_param\": True,\n    \"rol_window\": \"60min\",\n\n    # key requirement from user\n    \"SOLO_use_merged_MAG\": True,\n    \"SOLO_merged_fs\": 256,\n\n    \"Big_Gaps\": {\n        \"E_big_gaps\": 10,\n        \"SC_pot_big_gaps\": 10,\n        \"Mag_big_gaps\": 500,\n        \"Par_big_gaps\": 500,\n        \"QTN_big_gaps\": 10,\n    },\n\n    \"cut_in_small_windows\": {\n        \"flag\": False,\n        \"njobs\": 1,\n        \"Step\": \"5s\",\n        \"duration\": \"30s\",\n    },\n}\n\nvars_2_downnload = {\n    \"mag\": None,\n    \"swa\": None,\n    \"rpw\": None,\n    \"ephem\": None,\n}\n\nsave_base.mkdir(parents=True, exist_ok=True)\nprint(\"Save path:\", save_base)\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Build 1-day, non-overlapping intervals\nstart_ts = pd.Timestamp(start_date)\nend_ts = pd.Timestamp(end_date)\n\nedges = pd.date_range(start=start_ts, end=end_ts, freq=\"1D\")\nif len(edges) < 2:\n    raise ValueError(\"Need at least 1 full day in [start_date, end_date].\")\n\nintervals = pd.DataFrame({\n    \"Start\": edges[:-1],\n    \"End\": edges[1:]\n})\n\nprint(f\"Generated {len(intervals)} daily intervals (no overlap).\")\nintervals.head()\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "def _folder_name(start_time, end_time):\n    tfmt = \"%Y-%m-%d_%H-%M-%S\"\n    return f\"{start_time.strftime(tfmt)}_{end_time.strftime(tfmt)}_sc_0\"\n\n\ndef _safe_stat(series, reducer=\"mean\"):\n    if series is None:\n        return np.nan\n    series = pd.to_numeric(series, errors=\"coerce\")\n    if series.notna().sum() == 0:\n        return np.nan\n    if reducer == \"mean\":\n        return float(np.nanmean(series.values))\n    if reducer == \"median\":\n        return float(np.nanmedian(series.values))\n    if reducer == \"std\":\n        return float(np.nanstd(series.values))\n    raise ValueError(\"Unsupported reducer\")\n\n\nrows = []\n\nfor ii, row in intervals.iterrows():\n    start_time = row[\"Start\"]\n    end_time = row[\"End\"]\n\n    (\n        big_gaps_SC_pot,\n        big_gaps,\n        big_gaps_par,\n        big_gaps_elec,\n        big_gaps_qtn,\n        flag_good,\n        final_dict,\n        general_dict,\n        sig_df,\n        dfdis,\n        misc,\n    ) = download.main_function(\n        start_time,\n        end_time,\n        settings,\n        vars_2_downnload,\n        cdf_lib_path,\n        credentials,\n    )\n\n    available = int(flag_good == 1 and isinstance(sig_df, pd.DataFrame) and len(sig_df) > 0)\n\n    if available:\n        sig_1min = sig_df.resample(\"1min\").mean(numeric_only=True)\n        beta = sig_1min.get(\"beta\")\n        sigma_c = sig_1min.get(\"sigma_c\")\n\n        beta_mean = _safe_stat(beta, \"mean\")\n        beta_median = _safe_stat(beta, \"median\")\n        sigma_c_abs_mean = _safe_stat(np.abs(sigma_c), \"mean\")\n        sigma_c_abs_median = _safe_stat(np.abs(sigma_c), \"median\")\n\n        # Save \"usual files\" for successful intervals\n        if save_usual_files:\n            folder = save_base / _folder_name(start_time, end_time)\n            folder.mkdir(parents=True, exist_ok=True)\n\n            pd.to_pickle(final_dict, folder / \"final.pkl\")\n            pd.to_pickle(general_dict, folder / \"general.pkl\")\n            pd.to_pickle(sig_df, folder / \"sig_c_sig_r.pkl\")\n            pd.to_pickle(big_gaps, folder / \"mag_gaps.pkl\")\n            pd.to_pickle(big_gaps_qtn, folder / \"qtn_gaps.pkl\")\n            pd.to_pickle(big_gaps_par, folder / \"par_gaps.pkl\")\n            pd.to_pickle(big_gaps_SC_pot, folder / \"sc_pot_gaps.pkl\")\n            pd.to_pickle(big_gaps_elec, folder / \"elec_gaps.pkl\")\n            pd.to_pickle(dfdis, folder / \"distance.pkl\")\n            pd.to_pickle(misc, folder / \"misc.pkl\")\n\n    else:\n        beta_mean = np.nan\n        beta_median = np.nan\n        sigma_c_abs_mean = np.nan\n        sigma_c_abs_median = np.nan\n\n    rows.append({\n        \"Start\": start_time,\n        \"End\": end_time,\n        \"available\": available,\n        \"beta_mean_1min\": beta_mean,\n        \"beta_median_1min\": beta_median,\n        \"abs_sigma_c_mean_1min\": sigma_c_abs_mean,\n        \"abs_sigma_c_median_1min\": sigma_c_abs_median,\n    })\n\nsummary = pd.DataFrame(rows)\nsummary\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Persist summary products\nsummary_path = save_base / \"daily_merged_mag_availability_summary.csv\"\nsummary.to_csv(summary_path, index=False)\n\navailable_days = int(summary[\"available\"].sum())\ntotal_days = int(len(summary))\nprint(f\"Available days: {available_days}/{total_days}\")\nprint(f\"Summary saved to: {summary_path}\")\n\nsummary.head(20)\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## A smarter strategy (recommended before long runs)\n\nIf you are scanning long time ranges, do this in two phases:\n\n1. **Pre-screen merged MAG availability only** (cheap):\n   - Query merged MAG products day-by-day (no plasma diagnostics yet).\n   - Keep only days where merged MAG exists.\n2. **Run full diagnostics only on candidate days**:\n   - For candidate days, compute 1-minute `beta` and `sigma_c` with the full pipeline.\n\nWhy this helps:\n- You avoid expensive full-pipeline failures on days with no merged MAG.\n- You still get physically consistent `beta` and `sigma_c` from synchronized plasma + MAG data.\n\nIf you want, I can add a dedicated pre-screen helper cell that uses SOAR/pySPEDAS metadata first, then auto-runs the full diagnostics only on valid days.\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### Motivation
- Provide a reproducible notebook to scan Solar Orbiter merged MAG availability day-by-day and compute daily plasma diagnostics (`beta` and `sigma_c`) at 1-minute cadence.  
- Force the pipeline to use the SOAR/merged MAG product (`SOLO_use_merged_MAG=True`) so merged-MAG availability can be evaluated directly.  
- Save the canonical MHDTurbPy per-interval outputs for successful days so downstream analysis can reuse the pipeline outputs.  

### Description
- Add `Notebooks_Examples/SOLO_merged_MAG_daily_availability.ipynb` which builds non-overlapping 1-day intervals over a user-specified date range and evaluates each interval programmatically.  
- The notebook calls `download.main_function` for each daily interval with settings that include `SOLO_use_merged_MAG: True`, `part_resol`/`MAG_resol` set to 60 (1-minute cadence), and `duration`/`Step` set to `24H`.  
- For intervals that succeed, the notebook resamples the diagnostics timeseries (`sig_c_sig_r`) to 1-minute, computes summary statistics for `beta` and `sigma_c` (mean/median/absolute-mean), and saves the usual output files (`final.pkl`, `general.pkl`, `sig_c_sig_r.pkl`, gap files, distance/misc pickles) into a dedicated folder.  
- Includes a short guidance cell recommending a two-phase strategy (pre-screen merged MAG availability first, then run full diagnostics on candidate days) to reduce runtime and failures on long scans.  

### Testing
- Validated the new notebook JSON with `python -m json.tool Notebooks_Examples/SOLO_merged_MAG_daily_availability.ipynb` which completed successfully.  
- The notebook file was written to `Notebooks_Examples/SOLO_merged_MAG_daily_availability.ipynb` and added to the repository (creation recorded in the commit).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69943f2ece748320a4f7548ac52da810)

## Summary by Sourcery

Add a Solar Orbiter example notebook to scan daily merged-MAG data availability, compute 1-minute plasma diagnostics, and persist per-day outputs and a summary table.

New Features:
- Introduce a SOLO merged MAG daily availability notebook that automates non-overlapping 1-day interval evaluation over a user-defined date range.
- Compute and record 1-minute cadence summary statistics for plasma beta and sigma_c for days with successful merged MAG runs.
- Persist standard MHDTurbPy per-interval output files and a CSV summary of daily availability and diagnostics for downstream analysis.

Documentation:
- Document a recommended two-phase workflow for long time-range scans, separating fast merged-MAG availability pre-screening from full diagnostics runs.