### PR TITLE
Revise SOLO merged-MAG notebook with fast SOAR pre-screen

### DIFF
--- a/Notebooks_Examples/SOLO_merged_MAG_daily_availability.ipynb
+++ b/Notebooks_Examples/SOLO_merged_MAG_daily_availability.ipynb
@@ -1,0 +1,79 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Fast Solar Orbiter merged MAG availability scan + daily diagnostics\n\nThis notebook revises the previous approach by adding a **fast pre-screen step using the Solar Orbiter Archive (SOAR)**:\n\n1. Query SOAR metadata day-by-day for merged MAG product availability (**no full data processing**).\n2. Run the full MHDTurbPy pipeline only for days that appear available.\n3. Downsample diagnostics to **1-minute cadence** and summarize `beta` and `sigma_c`.\n4. Save the usual MHDTurbPy files for successful days.\n\nIt keeps the requirement `SOLO_use_merged_MAG = True`.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from pathlib import Path\nimport importlib.util\n\nimport numpy as np\nimport pandas as pd\n\n\ndef _find_repo_root(start: Path) -> Path:\n    current = start.resolve()\n    for candidate in (current, *current.parents):\n        if (candidate / \"functions\").is_dir() and (candidate / \"pyspedas\").is_dir():\n            return candidate\n    raise RuntimeError(\"Could not locate MHDTurbPy root (missing functions/ and pyspedas/).\")\n\n\nroot_dir = _find_repo_root(Path.cwd())\npath_setup_file = root_dir / \"functions\" / \"path_setup.py\"\nspec = importlib.util.spec_from_file_location(\"mhdturbpy_path_setup\", path_setup_file)\nif spec is None or spec.loader is None:\n    raise RuntimeError(f\"Could not load path setup from {path_setup_file}\")\npath_setup = importlib.util.module_from_spec(spec)\nspec.loader.exec_module(path_setup)\n\nroot_dir = path_setup.ensure_project_paths(\n    start=Path.cwd(),\n    include_downloading_helpers=True,\n    include_anisotropy_toolbox=True,\n    include_sc_pos=True,\n)\n\nfrom functions import download_data as download\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# ---------- User configuration ----------\ncdf_lib_path = \"/Applications/cdf/cdf/lib\"  # update for your machine if needed\ncredentials = None\n\n# Scan window (end is exclusive for daily slicing)\nstart_date = \"2022-10-01 00:00\"\nend_date   = \"2022-11-01 00:00\"\n\n# SOAR merged product options\nSOLO_merged_fs = 256  # 256 or 4096\nin_rtn = 1            # 1 -> RTN product, 0 -> SRF product\n\n# Save options\nsave_usual_files = True\nsave_base = Path(root_dir) / \"examples\" / \"downloaded_intervals\" / \"SOLO_merged_MAG_daily\"\nsave_base.mkdir(parents=True, exist_ok=True)\n\nsettings = {\n    \"Data_path\": Path(root_dir) / \"data\",\n    \"save_destination\": Path(root_dir) / \"examples\" / \"downloaded_intervals\",\n    \"sc\": \"SOLO\",\n    \"in_rtn\": in_rtn,\n    \"use_local_data\": False,\n\n    # daily non-overlapping intervals\n    \"start_date\": start_date,\n    \"end_date\": end_date,\n    \"multiple_intervals\": False,\n    \"duration\": \"24H\",\n    \"Step\": \"24H\",\n    \"addit_time_around\": 1,\n\n    # 1-minute products\n    \"part_resol\": 60,\n    \"MAG_resol\": 60,\n    \"upsample_low_freq_ts\": False,\n\n    \"overwrite_files\": 1,\n    \"must_have_qtn\": False,\n    \"Max_par_missing\": 30,\n    \"gap_time_threshold\": 5,\n    \"save_all\": True,\n\n    \"estimate_derived_param\": True,\n    \"rol_window\": \"60min\",\n\n    # Required by your request\n    \"SOLO_use_merged_MAG\": True,\n    \"SOLO_merged_fs\": SOLO_merged_fs,\n\n    \"Big_Gaps\": {\n        \"E_big_gaps\": 10,\n        \"SC_pot_big_gaps\": 10,\n        \"Mag_big_gaps\": 500,\n        \"Par_big_gaps\": 500,\n        \"QTN_big_gaps\": 10,\n    },\n\n    \"cut_in_small_windows\": {\n        \"flag\": False,\n        \"njobs\": 1,\n        \"Step\": \"5s\",\n        \"duration\": \"30s\",\n    },\n}\n\nvars_2_downnload = {\"mag\": None, \"swa\": None, \"rpw\": None, \"ephem\": None}\n\nframe = \"rtn\" if in_rtn else \"srf\"\nmerged_product = f\"multi-mag-rpw-scm-merged-{frame}-{SOLO_merged_fs}\"\nsettings[\"SOLO_merged_product\"] = merged_product\n\nprint(\"Save path:\", save_base)\nprint(\"Merged product:\", merged_product)\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Daily non-overlapping intervals\nstart_ts = pd.Timestamp(start_date)\nend_ts = pd.Timestamp(end_date)\n\nedges = pd.date_range(start=start_ts, end=end_ts, freq=\"1D\")\nif len(edges) < 2:\n    raise ValueError(\"Need at least 1 full day in [start_date, end_date].\")\n\nintervals = pd.DataFrame({\"Start\": edges[:-1], \"End\": edges[1:]})\nprint(f\"Generated {len(intervals)} daily intervals.\")\nintervals.head()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Phase 1 (fast): pre-screen with SOAR metadata only\n\nThis step checks archive availability by querying SOAR with `sunpy`/`sunpy_soar` search.\nIf `sunpy_soar` is unavailable in your environment, the notebook falls back to a conservative mode where all days are treated as candidates (still correct, just slower).\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "def precheck_soar_availability(interval_df, product):\n    rows = []\n    try:\n        from sunpy.net import Fido\n        import sunpy.net.attrs as a\n        import sunpy_soar  # noqa: F401\n        soar_ok = True\n    except Exception as e:\n        print(\"SOAR metadata pre-check unavailable:\", e)\n        print(\"Falling back to full-run candidates for all days.\")\n        soar_ok = False\n\n    if not soar_ok:\n        for _, r in interval_df.iterrows():\n            rows.append({\n                \"Start\": r[\"Start\"],\n                \"End\": r[\"End\"],\n                \"soar_available\": 1,\n                \"soar_n_records\": np.nan,\n            })\n        return pd.DataFrame(rows)\n\n    for _, r in interval_df.iterrows():\n        t0 = pd.Timestamp(r[\"Start\"])\n        t1 = pd.Timestamp(r[\"End\"])\n\n        try:\n            qr = Fido.search(a.Time(t0, t1), a.soar.Product(product))\n            nrec = len(qr)\n            available = int(nrec > 0)\n        except Exception:\n            nrec = np.nan\n            available = 0\n\n        rows.append({\n            \"Start\": t0,\n            \"End\": t1,\n            \"soar_available\": available,\n            \"soar_n_records\": nrec,\n        })\n\n    return pd.DataFrame(rows)\n\n\nprecheck = precheck_soar_availability(intervals, merged_product)\nprint(\n    f\"SOAR candidate days: {int(precheck.soar_available.sum())}/{len(precheck)}\"\n)\nprecheck.head(20)\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Phase 2: run full diagnostics only on candidate days\n\nFor candidate days, run `download.main_function(...)`, then compute 1-minute summary statistics of `beta` and `sigma_c`.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "def _folder_name(start_time, end_time):\n    tfmt = \"%Y-%m-%d_%H-%M-%S\"\n    return f\"{start_time.strftime(tfmt)}_{end_time.strftime(tfmt)}_sc_0\"\n\n\ndef _safe_stat(series, reducer=\"mean\"):\n    if series is None:\n        return np.nan\n    series = pd.to_numeric(series, errors=\"coerce\")\n    if series.notna().sum() == 0:\n        return np.nan\n    if reducer == \"mean\":\n        return float(np.nanmean(series.values))\n    if reducer == \"median\":\n        return float(np.nanmedian(series.values))\n    return np.nan\n\n\nrows = []\ncandidates = precheck[precheck[\"soar_available\"] == 1].copy()\n\nfor _, row in candidates.iterrows():\n    start_time = row[\"Start\"]\n    end_time = row[\"End\"]\n\n    (\n        big_gaps_SC_pot,\n        big_gaps,\n        big_gaps_par,\n        big_gaps_elec,\n        big_gaps_qtn,\n        flag_good,\n        final_dict,\n        general_dict,\n        sig_df,\n        dfdis,\n        misc,\n    ) = download.main_function(\n        start_time,\n        end_time,\n        settings,\n        vars_2_downnload,\n        cdf_lib_path,\n        credentials,\n    )\n\n    pipeline_ok = int(flag_good == 1 and isinstance(sig_df, pd.DataFrame) and len(sig_df) > 0)\n\n    if pipeline_ok:\n        sig_1min = sig_df.resample(\"1min\").mean(numeric_only=True)\n        beta = sig_1min.get(\"beta\")\n        sigma_c = sig_1min.get(\"sigma_c\")\n\n        beta_mean = _safe_stat(beta, \"mean\")\n        beta_median = _safe_stat(beta, \"median\")\n        sigma_c_abs_mean = _safe_stat(np.abs(sigma_c), \"mean\")\n        sigma_c_abs_median = _safe_stat(np.abs(sigma_c), \"median\")\n\n        if save_usual_files:\n            folder = save_base / _folder_name(start_time, end_time)\n            folder.mkdir(parents=True, exist_ok=True)\n\n            pd.to_pickle(final_dict, folder / \"final.pkl\")\n            pd.to_pickle(general_dict, folder / \"general.pkl\")\n            pd.to_pickle(sig_df, folder / \"sig_c_sig_r.pkl\")\n            pd.to_pickle(big_gaps, folder / \"mag_gaps.pkl\")\n            pd.to_pickle(big_gaps_qtn, folder / \"qtn_gaps.pkl\")\n            pd.to_pickle(big_gaps_par, folder / \"par_gaps.pkl\")\n            pd.to_pickle(big_gaps_SC_pot, folder / \"sc_pot_gaps.pkl\")\n            pd.to_pickle(big_gaps_elec, folder / \"elec_gaps.pkl\")\n            pd.to_pickle(dfdis, folder / \"distance.pkl\")\n            pd.to_pickle(misc, folder / \"misc.pkl\")\n    else:\n        beta_mean = np.nan\n        beta_median = np.nan\n        sigma_c_abs_mean = np.nan\n        sigma_c_abs_median = np.nan\n\n    rows.append({\n        \"Start\": start_time,\n        \"End\": end_time,\n        \"soar_available\": int(row[\"soar_available\"]),\n        \"soar_n_records\": row[\"soar_n_records\"],\n        \"pipeline_available\": pipeline_ok,\n        \"beta_mean_1min\": beta_mean,\n        \"beta_median_1min\": beta_median,\n        \"abs_sigma_c_mean_1min\": sigma_c_abs_mean,\n        \"abs_sigma_c_median_1min\": sigma_c_abs_median,\n    })\n\nresults_candidates = pd.DataFrame(rows)\nresults_candidates.head(20)\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Merge phase-1 and phase-2 outputs into one final table\nsummary = precheck.merge(\n    results_candidates,\n    on=[\"Start\", \"End\", \"soar_available\", \"soar_n_records\"],\n    how=\"left\",\n)\n\nsummary[\"pipeline_available\"] = summary[\"pipeline_available\"].fillna(0).astype(int)\n\nsummary_path = save_base / \"daily_merged_mag_availability_summary.csv\"\nsummary.to_csv(summary_path, index=False)\n\nprint(f\"SOAR-available days: {int(summary['soar_available'].sum())}/{len(summary)}\")\nprint(f\"Pipeline-success days: {int(summary['pipeline_available'].sum())}/{len(summary)}\")\nprint(f\"Saved summary: {summary_path}\")\n\nsummary.head(30)\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Practical recommendation\n\nThis is the fastest robust pattern:\n\n- Keep the SOAR pre-check as the default for long date ranges.\n- Run full diagnostics only on SOAR-candidate days.\n- If you only need a quick climatology, you can save only the summary CSV and skip writing per-day pickles.\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### Motivation

- Reduce runtime and failed runs by pre-screening Solar Orbiter merged-MAG availability via the Solar Orbiter Archive (SOAR) metadata rather than running the full pipeline for every day.  
- Make it straightforward to target the SOAR merged product (`multi-mag-rpw-scm-merged-...`) while preserving the existing `SOLO_use_merged_MAG` workflow.  
- Provide a concise per-day summary that distinguishes archive-available days from days where the full MHDTurbPy pipeline succeeded.  

### Description

- Replace `Notebooks_Examples/SOLO_merged_MAG_daily_availability.ipynb` with a revised notebook that implements a two-phase workflow: a fast SOAR metadata pre-check followed by full diagnostics only for candidate days.  
- Implement `precheck_soar_availability(...)` that uses `sunpy`/`sunpy_soar`/`Fido.search` to flag days with merged-MAG records and falls back to treating all days as candidates if SOAR tooling is unavailable.  
- For candidate days the notebook calls `download.main_function(...)`, then resamples `sig_df` to 1-minute cadence and computes summary statistics for `beta` and `sigma_c`, saving the usual per-day pickles when successful.  
- Emit a merged CSV summary (`daily_merged_mag_availability_summary.csv`) containing `soar_available` and `pipeline_available` flags plus the computed 1-minute summary metrics.  

### Testing

- Validated the produced notebook JSON with `python -m json.tool Notebooks_Examples/SOLO_merged_MAG_daily_availability.ipynb`, which completed successfully.  
- Confirmed the notebook file was written to `Notebooks_Examples/SOLO_merged_MAG_daily_availability.ipynb` and contains the new pre-check and pipeline-invocation cells.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69943f2ece748320a4f7548ac52da810)

## Summary by Sourcery

Introduce a new Solar Orbiter merged-MAG daily availability notebook that pre-screens days via SOAR metadata and runs the full MHDTurbPy pipeline only for candidate days, producing per-day diagnostics and a consolidated summary CSV.

New Features:
- Add a two-phase SOLO merged-MAG availability workflow notebook that first queries SOAR metadata for merged product availability and then runs the full pipeline only on candidate days.
- Generate per-day 1-minute cadence diagnostics summarizing beta and sigma_c for successful pipeline runs.
- Emit a consolidated CSV report capturing SOAR availability, pipeline success, and 1-minute summary metrics for each scanned day.