### PR TITLE
Add general ballistic backmapping CLI and quickstart notebook

### DIFF
--- a/Notebooks_Examples/ballistic_backmapping_quickstart.ipynb
+++ b/Notebooks_Examples/ballistic_backmapping_quickstart.ipynb
@@ -1,0 +1,134 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Ballistic backmapping quickstart (general spacecraft)\n",
+        "\n",
+        "This notebook demonstrates how to run the repository's general ballistic backmapping pipeline and inspect outputs.\n",
+        "\n",
+        "It calls: `functions/sc_pos/ballistic_backmap.py`\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from pathlib import Path\n",
+        "import subprocess\n",
+        "import sys\n",
+        "import pandas as pd\n",
+        "import matplotlib.pyplot as plt\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Adjust these values as needed for your dataset/spacecraft\n",
+        "repo_root = Path.cwd().resolve().parent if Path.cwd().name == 'Notebooks_Examples' else Path.cwd().resolve()\n",
+        "final_pkl = repo_root / 'examples' / 'SOLO' / '2022-10-01_00-00-00_2022-10-03_00-00-00_sc_0' / 'final.pkl'\n",
+        "outdir = repo_root / 'examples' / 'figures' / 'ballistic_backmap_demo'\n",
+        "target = 'SOLO'  # e.g. SOLO, PSP, WIND, ACE, -144\n",
+        "target_label = 'Solar Orbiter'\n",
+        "start = '2022-10-01T00:00:00Z'\n",
+        "stop = '2022-10-02T00:00:00Z'\n",
+        "cadence = '60min'\n",
+        "smooth = '12h'\n",
+        "\n",
+        "print('repo_root:', repo_root)\n",
+        "print('final_pkl exists:', final_pkl.exists())\n",
+        "print('outdir:', outdir)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "cmd = [\n",
+        "    sys.executable,\n",
+        "    str(repo_root / 'functions' / 'sc_pos' / 'ballistic_backmap.py'),\n",
+        "    '--final_pkl', str(final_pkl),\n",
+        "    '--outdir', str(outdir),\n",
+        "    '--target', target,\n",
+        "    '--target_label', target_label,\n",
+        "    '--start', start,\n",
+        "    '--stop', stop,\n",
+        "    '--cadence', cadence,\n",
+        "    '--smooth', smooth,\n",
+        "    '--cache_ephem',\n",
+        "]\n",
+        "\n",
+        "print('Running command:\n', ' '.join(cmd))\n",
+        "res = subprocess.run(cmd, cwd=repo_root, text=True, capture_output=True)\n",
+        "print('Return code:', res.returncode)\n",
+        "if res.stdout:\n",
+        "    print('--- stdout ---')\n",
+        "    print(res.stdout)\n",
+        "if res.stderr:\n",
+        "    print('--- stderr ---')\n",
+        "    print(res.stderr)\n",
+        "\n",
+        "if res.returncode != 0:\n",
+        "    raise RuntimeError('Backmapping command failed. See stdout/stderr above.')\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "pngs = [\n",
+        "    outdir / 'source_surface_polarity.png',\n",
+        "    outdir / 'source_surface_speed.png',\n",
+        "    outdir / 'source_surface_ram_pressure.png',\n",
+        "]\n",
+        "\n",
+        "fig, axes = plt.subplots(3, 1, figsize=(12, 12), constrained_layout=True)\n",
+        "for ax, p in zip(axes, pngs):\n",
+        "    if not p.exists():\n",
+        "        ax.set_title(f'Missing output: {p.name}')\n",
+        "        ax.axis('off')\n",
+        "        continue\n",
+        "    img = plt.imread(p)\n",
+        "    ax.imshow(img)\n",
+        "    ax.set_title(p.name)\n",
+        "    ax.axis('off')\n",
+        "plt.show()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "ts_path = outdir / 'ballistic_backmap_timeseries.pkl'\n",
+        "ts = pd.read_pickle(ts_path)\n",
+        "print('timeseries shape:', ts.shape)\n",
+        "display(ts[[c for c in ['Br_large', 'Vr_large', 'Np_large', 'phi_src', 'lat_src', 'Pram'] if c in ts.columns]].head())\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/functions/sc_pos/ballistic_backmap.py
+++ b/functions/sc_pos/ballistic_backmap.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""General ballistic backmapping to source-surface maps from MHDTurbPy final.pkl.
+
+This script performs *ballistic backmapping* from in situ measurements to a source
+surface (default 2.5 R_sun). In ballistic backmapping, each plasma parcel is assumed
+to propagate radially at an observed bulk speed, and source Carrington longitude is
+estimated by subtracting/adding the Sun's rigid rotation during transit.
+
+This is different from PFSS field-line tracing:
+- Ballistic mapping: maps (lon, lat) to a source surface using radial propagation
+  and solar rotation only.
+- PFSS tracing: starts from source-surface points and follows modeled magnetic
+  field lines down to the photosphere; this optional extra step is NOT required for
+  the source-surface plots produced here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable, Optional, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from functions.sc_pos.horizons_sun_lonlat import resolve_spacecraft_spkid, ballistic_source_longitude
+
+BR_CANDIDATES = ["Br", "B_R", "B_r", "BRTN_R"]
+VR_CANDIDATES = ["Vr", "V_R", "Vx", "V_r", "V", "|V|"]
+NP_CANDIDATES = ["Np", "np", "N_p", "n_p", "proton_density"]
+
+
+def _to_utc_index(df: pd.DataFrame, name: str) -> pd.DataFrame:
+    out = df.copy()
+    out.index = pd.to_datetime(out.index, utc=True)
+    out = out[~out.index.duplicated(keep="first")].sort_index()
+    if out.empty:
+        raise ValueError(f"{name} is empty after time parsing.")
+    return out
+
+
+def _find_col(columns: Iterable[str], candidates: Sequence[str]) -> Optional[str]:
+    cols = list(columns)
+    for cand in candidates:
+        if cand in cols:
+            return cand
+    lower_to_orig = {str(c).lower(): c for c in cols}
+    for cand in candidates:
+        if cand.lower() in lower_to_orig:
+            return lower_to_orig[cand.lower()]
+    return None
+
+
+def _extract_frames(obj: object) -> tuple[pd.DataFrame, pd.DataFrame, list[str]]:
+    def as_df(x: object) -> Optional[pd.DataFrame]:
+        return x if isinstance(x, pd.DataFrame) else None
+
+    if isinstance(obj, pd.DataFrame):
+        df = _to_utc_index(obj, "final dataframe")
+        return df, df, list(df.columns)
+
+    if not isinstance(obj, dict):
+        raise TypeError(f"Unsupported final.pkl object type: {type(obj)}")
+
+    top_keys = list(obj.keys())
+    mag_df = None
+    par_df = None
+
+    mag_obj = obj.get("Mag") or obj.get("mag")
+    if isinstance(mag_obj, dict):
+        mag_df = as_df(mag_obj.get("B_resampled"))
+    elif isinstance(mag_obj, pd.DataFrame):
+        mag_df = mag_obj
+
+    par_obj = obj.get("Par") or obj.get("par") or obj.get("plasma")
+    if isinstance(par_obj, dict):
+        par_df = as_df(par_obj.get("V_resampled"))
+    elif isinstance(par_obj, pd.DataFrame):
+        par_df = par_obj
+
+    if mag_df is None or par_df is None:
+        dfs = {k: v for k, v in obj.items() if isinstance(v, pd.DataFrame)}
+        if mag_df is None:
+            for v in dfs.values():
+                if _find_col(v.columns, BR_CANDIDATES):
+                    mag_df = v
+                    break
+        if par_df is None:
+            for v in dfs.values():
+                if _find_col(v.columns, VR_CANDIDATES) and _find_col(v.columns, NP_CANDIDATES):
+                    par_df = v
+                    break
+
+    if mag_df is None or par_df is None:
+        raise ValueError(
+            "Could not identify MAG and plasma dataframes in final.pkl. "
+            f"Top-level keys: {top_keys}."
+        )
+
+    mag_df = _to_utc_index(mag_df, "MAG dataframe")
+    par_df = _to_utc_index(par_df, "plasma dataframe")
+    available = sorted(set(map(str, mag_df.columns)).union(map(str, par_df.columns)))
+    return mag_df, par_df, available
+
+
+def _query_ephem(
+    times: pd.DatetimeIndex,
+    cadence: str,
+    cache_file: Optional[Path],
+    target: str,
+) -> pd.DataFrame:
+    if cache_file and cache_file.exists():
+        cached = pd.read_pickle(cache_file)
+        if isinstance(cached, pd.DataFrame) and {"lon_carr", "lat", "r_au"}.issubset(cached.columns):
+            cached = _to_utc_index(cached, "cached ephemeris")
+            if cached.index.min() <= times.min() and cached.index.max() >= times.max():
+                return cached
+
+    try:
+        from astropy import units as u
+        from sunpy.coordinates.ephemeris import get_horizons_coord
+        from sunpy.coordinates.frames import HeliographicCarrington
+    except Exception as exc:
+        raise RuntimeError(
+            "sunpy/astropy is required for Horizons ephemeris queries. "
+            "Install with: pip install sunpy astropy"
+        ) from exc
+
+    spkid = resolve_spacecraft_spkid(target)
+    query = get_horizons_coord(
+        body=spkid,
+        time={"start": times.min().isoformat(), "stop": times.max().isoformat(), "step": cadence},
+        id_type="id",
+    )
+    hgc = query.transform_to(HeliographicCarrington(obstime=query.obstime))
+    ephem = pd.DataFrame(
+        {
+            "lon_carr": hgc.lon.to_value(u.deg),
+            "lat": hgc.lat.to_value(u.deg),
+            "r_au": hgc.radius.to_value(u.AU),
+        },
+        index=pd.to_datetime(hgc.obstime.datetime64, utc=True),
+    ).sort_index()
+
+    if cache_file:
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        ephem.to_pickle(cache_file)
+
+    return ephem
+
+
+def _interp_to_index(df: pd.DataFrame, idx: pd.DatetimeIndex) -> pd.DataFrame:
+    return df.reindex(df.index.union(idx)).sort_index().interpolate(method="time").reindex(idx)
+
+
+def _size_from_metric(x: pd.Series, smin: float = 5.0, smax: float = 200.0) -> pd.Series:
+    valid = x.replace([np.inf, -np.inf], np.nan)
+    lo, hi = np.nanpercentile(valid, [5, 95]) if np.isfinite(valid).any() else (0.0, 1.0)
+    if not np.isfinite(lo) or not np.isfinite(hi) or hi <= lo:
+        return pd.Series(np.full(len(x), (smin + smax) / 2.0), index=x.index)
+    return smin + (smax - smin) * np.clip((valid - lo) / (hi - lo), 0, 1)
+
+
+def run(args: argparse.Namespace) -> list[Path]:
+    final_obj = pd.read_pickle(args.final_pkl)
+    mag_df, par_df, available_cols = _extract_frames(final_obj)
+
+    br_col = _find_col(mag_df.columns, BR_CANDIDATES)
+    vr_col = _find_col(par_df.columns, VR_CANDIDATES)
+    np_col = _find_col(par_df.columns, NP_CANDIDATES)
+    if br_col is None or vr_col is None or np_col is None:
+        raise ValueError(
+            "Failed to find required columns. "
+            f"Need Br from {BR_CANDIDATES}, Vr from {VR_CANDIDATES}, Np from {NP_CANDIDATES}. "
+            f"Available columns: {available_cols}"
+        )
+
+    plasma = par_df[[vr_col, np_col]].rename(columns={vr_col: "Vr", np_col: "Np"})
+    if args.start:
+        plasma = plasma[plasma.index >= pd.to_datetime(args.start, utc=True)]
+    if args.stop:
+        plasma = plasma[plasma.index <= pd.to_datetime(args.stop, utc=True)]
+    if plasma.empty:
+        raise ValueError("No plasma samples in selected time range.")
+
+    mag = mag_df[[br_col]].rename(columns={br_col: "Br"})
+    data = plasma.join(_interp_to_index(mag, plasma.index), how="left")
+    data = data.resample(args.cadence).median() if args.cadence else data
+
+    smooth = pd.Timedelta(args.smooth)
+    for k in ["Br", "Vr", "Np"]:
+        data[f"{k}_large"] = data[k].rolling(smooth, min_periods=3).median()
+
+    cache_file = Path(args.outdir) / f"ephem_{args.target.replace(' ', '_')}.pkl" if args.cache_ephem else None
+    ephem = _query_ephem(data.index, args.cadence, cache_file, args.target)
+    data = data.join(_interp_to_index(ephem, data.index)[["lon_carr", "lat", "r_au"]])
+
+    phi_src, tau_days, fallback_flag = ballistic_source_longitude(
+        lon_carr_deg=data["lon_carr"],
+        r_au=data["r_au"],
+        vsw_kms=data["Vr_large"],
+        r_ss_rsun=args.r_ss_rsun,
+        omega_deg_per_day=args.omega_deg_per_day,
+        vsw_fallback_kms=args.vsw_fallback,
+    )
+    data["phi_src"] = phi_src
+    data["tau_days"] = tau_days
+    data["vsw_fallback_used"] = fallback_flag
+    data["lat_src"] = data["lat"]
+
+    data["Br_r2"] = data["Br_large"] * data["r_au"] ** 2
+    data["Np_r2"] = data["Np_large"] * data["r_au"] ** 2
+    data["Pram"] = data["Np_large"] * data["Vr_large"] ** 2
+    data["size"] = _size_from_metric(data["Pram"])
+
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+    stamp = data.index.max().strftime("%Y-%m-%d %H:%M UTC")
+    target_label = args.target_label or args.target
+
+    pol = np.sign(data["Br_large"])
+    colors = np.where(pol > 0, "red", np.where(pol < 0, "blue", "grey"))
+
+    fig1, ax1 = plt.subplots(figsize=(11, 4.5), constrained_layout=True)
+    ax1.scatter(data["phi_src"], data["lat_src"], c=colors, s=20, alpha=0.8, linewidths=0)
+    ax1.set(xlim=(0, 360), ylim=(-35, 35), xlabel="Source longitude (deg)", ylabel="Source latitude (deg)")
+    ax1.set_title(f"{target_label} MAG")
+    f1 = outdir / "source_surface_polarity.png"
+    fig1.savefig(f1, dpi=180)
+    plt.close(fig1)
+
+    fig2, ax2 = plt.subplots(figsize=(11, 4.5), constrained_layout=True)
+    sc2 = ax2.scatter(
+        data["phi_src"], data["lat_src"], c=data["Vr_large"], s=data["size"], cmap="viridis",
+        vmin=args.vmin, vmax=args.vmax, alpha=0.8, linewidths=0,
+    )
+    ax2.set(xlim=(0, 360), ylim=(-35, 35), xlabel="Source longitude (deg)", ylabel="Source latitude (deg)")
+    ax2.set_title(f"{target_label} SWA ({stamp})")
+    fig2.colorbar(sc2, ax=ax2).set_label("km/s")
+    f2 = outdir / "source_surface_speed.png"
+    fig2.savefig(f2, dpi=180)
+    plt.close(fig2)
+
+    fig3, ax3 = plt.subplots(figsize=(11, 4.5), constrained_layout=True)
+    top_thr = np.nanpercentile(data["Pram"], args.highlight_percentile) if np.isfinite(data["Pram"]).any() else np.inf
+    high = data["Pram"] >= top_thr
+    ax3.scatter(data.loc[~high, "phi_src"], data.loc[~high, "lat_src"], c=colors[~high], s=data.loc[~high, "size"], alpha=0.8, linewidths=0)
+    ax3.scatter(data.loc[high, "phi_src"], data.loc[high, "lat_src"], c=colors[high], s=data.loc[high, "size"], alpha=0.9, edgecolors="black", linewidths=0.5)
+    ax3.set(xlim=(0, 360), ylim=(-35, 35), xlabel="Source longitude (deg)", ylabel="Source latitude (deg)")
+    ax3.set_title(f"Ram pressure ({stamp})")
+    f3 = outdir / "source_surface_ram_pressure.png"
+    fig3.savefig(f3, dpi=180)
+    plt.close(fig3)
+
+    data.to_pickle(outdir / "ballistic_backmap_timeseries.pkl")
+    return [f1, f2, f3]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Reproducible, spacecraft-agnostic ballistic source-surface backmapping")
+    p.add_argument("--final_pkl", required=True, help="Path to MHDTurbPy final.pkl")
+    p.add_argument("--outdir", required=True, help="Output directory")
+    p.add_argument("--target", default="SOLO", help="Horizons spacecraft name/alias/SPKID (e.g. SOLO, PSP, -144)")
+    p.add_argument("--target_label", default=None, help="Optional display label for figure titles")
+    p.add_argument("--start", default=None, help="UTC start time (optional)")
+    p.add_argument("--stop", default=None, help="UTC stop time (optional)")
+    p.add_argument("--cadence", default="30min", help="Resample cadence + ephemeris step, e.g. 30min")
+    p.add_argument("--smooth", default="12h", help="Rolling window, e.g. 6h, 12h, 24h")
+    p.add_argument("--r_ss_rsun", type=float, default=2.5, help="Source-surface radius in R_sun")
+    p.add_argument("--omega_deg_per_day", type=float, default=14.1844, help="Rotation rate used in mapping")
+    p.add_argument("--vsw_fallback", type=float, default=400.0, help="Fallback speed (km/s) for invalid Vr")
+    p.add_argument("--vmin", type=float, default=300.0, help="Speed colormap minimum (km/s)")
+    p.add_argument("--vmax", type=float, default=900.0, help="Speed colormap maximum (km/s)")
+    p.add_argument("--highlight_percentile", type=float, default=99.0, help="Pram percentile for black-edge highlight")
+    p.add_argument("--cache_ephem", action="store_true", help="Cache ephemeris in outdir")
+    return p
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    files = run(args)
+    print("Wrote:")
+    for f in files:
+        print(f" - {f}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/functions/sc_pos/helpers.py
+++ b/functions/sc_pos/helpers.py
@@ -3,6 +3,8 @@ import numpy as np
 import plotly.graph_objects as go
 import astropy.constants as const
 
+from .horizons_sun_lonlat import ballistic_source_longitude
+
 
 def delta_long(r, rss, vsw, omega_deg_per_day=14.1844):
     sun_rot = (omega_deg_per_day * u.deg) / (24 * 3600 * u.s)
@@ -15,6 +17,22 @@ def ballistic_map(carr_coord, rss, vsw, omega_deg_per_day=14.1844):
     ss_lon = np.mod(ss_skycoord.to_value(u.deg), 360.0)
     return ss_lon
 
+
+
+
+
+
+def ballistic_source_longitude_from_df(df, lon_col="Carr_lon", r_col="Radius", vsw_col="Vr", **kwargs):
+    """Convenience wrapper for dataframe-based ballistic source-longitude mapping.
+
+    Expects longitude in deg, radius in km or AU, and speed in km/s.
+    If `r_col` max exceeds 10, values are treated as km and converted to AU.
+    """
+    lon = df[lon_col]
+    r = df[r_col]
+    r_au = r / 1.495978707e8 if float(np.nanmax(np.abs(r))) > 10 else r
+    vsw = df[vsw_col]
+    return ballistic_source_longitude(lon_carr_deg=lon, r_au=r_au, vsw_kms=vsw, **kwargs)
 
 def wrap(arr, difference=340):
     arr = np.array(arr, dtype=float, copy=True)

--- a/functions/sc_pos/horizons_sun_lonlat.py
+++ b/functions/sc_pos/horizons_sun_lonlat.py
@@ -8,6 +8,7 @@ from typing import List, Optional, Dict
 
 import pandas as pd
 import requests
+import numpy as np
 
 
 @dataclass(frozen=True)
@@ -212,6 +213,36 @@ def get_lonlat_xyz_timeseries(
 
     return TrajResult(target=str(canonical_target), spkid=str(spkid), df=out)
 
+
+
+def ballistic_source_longitude(
+    lon_carr_deg,
+    r_au,
+    vsw_kms,
+    r_ss_rsun: float = 2.5,
+    omega_deg_per_day: float = 14.1844,
+    vsw_fallback_kms: float = 400.0,
+):
+    """Vectorized ballistic mapping from spacecraft Carrington longitude to source-surface longitude.
+
+    Parameters are array-like and interpreted in degrees/AU/km/s.
+    Returns `(phi_src_deg_wrapped, tau_days, fallback_mask)`.
+    """
+    lon = pd.Series(lon_carr_deg, copy=False, dtype=float)
+    r = pd.Series(r_au, copy=False, dtype=float)
+    vsw = pd.Series(vsw_kms, copy=False, dtype=float)
+
+    fallback = (~np.isfinite(vsw)) | (vsw <= 0)
+    vsw_eff = vsw.copy()
+    vsw_eff[fallback] = float(vsw_fallback_kms)
+
+    rsun_au = 0.00465047
+    r_ss_au = float(r_ss_rsun) * rsun_au
+    km_per_au = 1.495978707e8
+    tau_days = (r - r_ss_au) * km_per_au / (vsw_eff * 86400.0)
+
+    phi_src = np.mod(lon - float(omega_deg_per_day) * tau_days, 360.0)
+    return phi_src, tau_days, fallback
 
 
 def main(argv: Optional[List[str]] = None) -> int:


### PR DESCRIPTION
### Motivation
- Provide a runnable end-to-end ballistic backmapping workflow that maps MHDTurbPy `final.pkl` measurements to source-surface maps and a timeseries for quick inspection.
- Make the mapping spacecraft-agnostic by adding a CLI that handles ephemeris queries, interpolation/resampling, smoothing and plotting so users can run the pipeline without custom glue code.
- Expose convenient helpers and a notebook so analysts can reproduce results, visualize the three primary maps (polarity, speed, ram pressure), and inspect the generated timeseries.

### Description
- Add `functions/sc_pos/ballistic_backmap.py`, a new CLI that: loads `final.pkl`, auto-detects MAG and plasma frames, resamples and smooths data, queries Horizons ephemeris via SunPy, computes vectorized ballistic source longitudes, and writes three PNG maps plus `ballistic_backmap_timeseries.pkl`.
- Add a vectorized `ballistic_source_longitude` implementation to `functions/sc_pos/horizons_sun_lonlat.py` that returns `(phi_src, tau_days, fallback_mask)` for array-like inputs and handles fallback speeds.
- Add `ballistic_source_longitude_from_df` to `functions/sc_pos/helpers.py` as a small DataFrame-oriented wrapper around the new vectorized mapping function.
- Add `Notebooks_Examples/ballistic_backmapping_quickstart.ipynb`, a minimal runnable notebook that parameterizes `final.pkl`, `outdir`, `target`, and time/cadence/smoothing options, runs the CLI via `subprocess`, prints stdout/stderr for debugging, displays the three generated PNGs, and previews key timeseries columns.

### Testing
- Validated the notebook JSON with `python -m json.tool Notebooks_Examples/ballistic_backmapping_quickstart.ipynb`, which succeeded.
- Created and wrote the notebook file programmatically during development to verify the notebook structure, which completed successfully.
- No automated unit tests were added for the new CLI; to fully exercise the pipeline run the notebook or invoke `functions/sc_pos/ballistic_backmap.py` and ensure `sunpy`/`astropy` are installed (the script raises a clear error if those dependencies are missing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994748d39d48320a87ddf6733a32cf9)

## Summary by Sourcery

Add a general, spacecraft-agnostic ballistic backmapping pipeline that converts MHDTurbPy final.pkl outputs into source-surface maps and a diagnostic timeseries.

New Features:
- Introduce a vectorized ballistic_source_longitude API for computing source-surface longitudes and transit times from spacecraft position and solar wind speed.
- Add a DataFrame-oriented ballistic_source_longitude_from_df helper for convenient ballistic mapping on tabular datasets.
- Add a ballistic_backmap CLI that ingests final.pkl, queries ephemeris data, performs smoothing/resampling, and produces polarity, speed, and ram-pressure source-surface maps plus a timeseries pickle.
- Provide a ballistic backmapping quickstart notebook that runs the CLI end-to-end for a chosen dataset and visualizes the generated outputs.

Enhancements:
- Extend ephemeris and heliographic utilities to support generalized ballistic backmapping workflows, including Horizons-based spacecraft ephemeris interpolation.